### PR TITLE
[WIP] Fixed build for CMAKE_BUILD_TYPE=Debug for Intel compilers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -253,6 +253,8 @@ set (CMAKE_Fortran_FLAGS_RELEASE "${GEOS_Fortran_FLAGS_VECT}")
 # moves them back to the 'bounds,uninit' GEOS used to build with.
 if (CMAKE_Fortran_COMPILER_ID MATCHES "Intel" AND CMAKE_BUILD_TYPE MATCHES Debug)
    string(REPLACE "all,noarg_temp_created" "bounds,uninit" _tmp "${GEOS_Fortran_FLAGS_DEBUG}")
+   string(REPLACE "SHELL:" "" _tmp "${_tmp}")  # lrb: this block cannot handle the SHELL: prefix; t.f., remove it
+   string(REPLACE ";" " " _tmp "${_tmp}")      # lrb: this block expects the options as space-separated list
    set (CMAKE_Fortran_FLAGS_DEBUG "${_tmp}")
 endif ()
 


### PR DESCRIPTION
There's a block in FMS/CMakeLists that is not compatible with the new style of multiword arguments and directly uses the `GEOS_Fortran_FLAGS_DEBUG` option. This block only runs if the compiler family is Intel, therefore this breaks the Intel build when `CMAKE_BUILD_TYPE=Debug`. The workaround is to remove the `SHELL:` prefix and change `GEOS_Fortran_FLAGS_DEBUG` to a space-separated list of arguments.

@TerribleNews, can you check if this fixes the Intel+Debug build for you? If so, I'll resolve the WIP status.